### PR TITLE
if roCtrl files found, order by filename, otherwise order by messageID

### DIFF
--- a/mosromgr/moscollection.py
+++ b/mosromgr/moscollection.py
@@ -119,12 +119,18 @@ class MosCollection:
             :class:`~mosromgr.exc.InvalidMosCollection` will be raised if one is
             not present. (keyword-only argument)
         """
-        logger.info("Making MosCollection from %s files", len(mos_file_paths))
-        mos_readers = sorted([
-            mr
-            for mr in [MosReader.from_file(mfp) for mfp in mos_file_paths]
-            if mr is not None
-        ])
+        if any("roCtrl" in filename for filename in mos_file_paths):
+            logger.info("Making MosCollection from %s files - roCtrl found so in filename order", len(mos_file_paths))
+            mos_readers = []
+            for mr in [MosReader.from_file(mfp) for mfp in mos_file_paths]:
+                mos_readers.append(mr)
+        else:
+            logger.info("Making MosCollection from %s files - messageID order", len(mos_file_paths))
+            mos_readers = sorted([
+                mr
+                for mr in [MosReader.from_file(mfp) for mfp in mos_file_paths]
+                if mr is not None
+            ])
         return cls(mos_readers, allow_incomplete=allow_incomplete)
 
     @classmethod


### PR DESCRIPTION
Resolves #8 

Tested with a recent News At Ten files collection. No failures, whereas 4 failures reported when running the previous release.

There's still an edge case to cover where an OM user deletes a story that is already 'live' in Mosart (i.e. a StoryStarted event has already been received), and the act of "unloading" it in Mosart raises a StoryEnded event - causing a race condition. That needs a separate ticket.